### PR TITLE
Quoting path on ProxyView

### DIFF
--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -26,7 +26,7 @@ class ProxyView(View):
         if self.add_remote_user and request.user.is_active:
             request_headers['REMOTE_USER'] = request.user.username
 
-        request_url = urljoin(self.base_url, path)
+        request_url = urljoin(self.base_url, urllib2.quote(path))
 
         if request.GET:
             request_url += '?' + urllib.urlencode(request.GET.items())


### PR DESCRIPTION
Quoting the path to avoid error with urls like:

"test/this/How%20Works"
the path is received with the white space. So it's necessary to quote it.
