### PR TITLE
Fixed request queries with variables with the same name

### DIFF
--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -69,6 +69,7 @@ def normalize_headers(request):
 
 def encode_items(items):
     encoded = []
-    for key, value in items:
-        encoded.append((key.encode('utf-8'), value.encode('utf-8')))
+    for key, values in items:
+        for value in values:
+            encoded.append((key.encode('utf-8'), value.encode('utf-8')))
     return encoded

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -49,8 +49,8 @@ class ProxyView(View):
         )
 
         if request.GET:
-            items = encode_items(request.GET.items())
-            request_url += '?' + urllib.urlencode(items)
+            get_data = encode_items(request.GET.lists())
+            request_url += '?' + urllib.urlencode(get_data)
 
         proxy_request = urllib2.Request(request_url, headers=request_headers)
 
@@ -58,7 +58,7 @@ class ProxyView(View):
             if 'multipart/form-data' in request_headers.get('Content-Type', ''):
                 proxy_request.add_data(request_payload)
             else:
-                post_data = request.POST.items()
+                post_data = encode_items(request.POST.lists())
                 proxy_request.add_data(urllib.urlencode(post_data))
 
         opener = urllib2.build_opener(NoHTTPRedirectHandler)


### PR DESCRIPTION
Now revproxy accept POST and GET queries with variables with the same name (eg, _col=1&col=2&col=3_).
