### PR TITLE
Changed way to get charset from response

### DIFF
--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -17,7 +17,9 @@ class HttpProxyResponse(HttpResponse):
         super(HttpProxyResponse, self).__init__(content, status=status,
                                                 *args, **kwargs)
 
-        if 'charset' in headers.get('content-type', '') and self._charset:
+        charset = getattr(self, 'charset', '_charset')
+
+        if 'charset' in headers.get('content-type', '') and charset:
             self.unicode_content = content.decode(self._charset)
         else:
             self.unicode_content = None


### PR DESCRIPTION
Obtaining charset through getattr instead of accessing it directly

Signed-off-by: Carlos Oliveira carlospecter@gmail.com
Signed-off-by: Alexandre Almeida alexandreab@live.com
