### PR TITLE
Reducing memory usage

### DIFF
--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -1,7 +1,5 @@
 from django.http import HttpResponse
 
-from .utils import get_charset
-
 HOP_BY_HOP_HEADERS = (
     'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
     'te', 'trailers', 'transfer-encoding', 'upgrade')
@@ -18,9 +16,6 @@ class HttpProxyResponse(HttpResponse):
         super(HttpProxyResponse, self).__init__(content, status=status,
                                                 content_type=content_type,
                                                 *args, **kwargs)
-
-        self._charset = get_charset(content_type)
-        self.unicode_content = content.decode(self._charset)
 
         for header, value in headers.items():
             if header.lower() not in HOP_BY_HOP_HEADERS:

--- a/revproxy/transformer.py
+++ b/revproxy/transformer.py
@@ -13,6 +13,7 @@ else:
     has_diazo = True
     from lxml import etree
 
+from .utils import get_charset
 
 doctype_re = re.compile(br"^<!DOCTYPE\s[^>]+>\s*", re.MULTILINE)
 
@@ -100,8 +101,9 @@ class DiazoTransformer(object):
 
         transform = etree.XSLT(output_xslt)
 
-        content = self.response.unicode_content or self.response.content
-        content_doc = etree.fromstring(content, parser=etree.HTMLParser())
+        charset = get_charset(self.response.get('Content-Type'))
+        content_doc = etree.fromstring(self.response.content.decode(charset),
+                                       parser=etree.HTMLParser())
 
         self.response.content = transform(content_doc)
 


### PR DESCRIPTION
Only decoding content for transformations. This will avoid decoding huge
blobs saving a considerable amount of memory.

Closes #16