### PR TITLE
Fix usage of the default ProxyView

### DIFF
--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -45,6 +45,7 @@ class ProxyView(View):
     default_content_type = 'application/octet-stream'
     retries = None
     rewrite = tuple()  # It will be overrided by a tuple inside tuple.
+    upstream = None
 
     def __init__(self, *args, **kwargs):
         super(ProxyView, self).__init__(*args, **kwargs)
@@ -57,10 +58,6 @@ class ProxyView(View):
         self.http = HTTP_POOLS
         self.log = logging.getLogger('revproxy.view')
         self.log.info("ProxyView created")
-
-    @property
-    def upstream(self):
-        raise NotImplementedError('Upstream server must be set')
 
     def get_upstream(self, path):
         upstream = self.upstream

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -26,11 +26,6 @@ class ViewTest(TestCase):
         view2 = ProxyView()
         self.assertIs(view1.http, view2.http)
 
-    def test_upstream_not_implemented(self):
-        proxy_view = ProxyView()
-        with self.assertRaises(NotImplementedError):
-            upstream = proxy_view.upstream
-
     def test_upstream_parsed_url_cache(self):
         class CustomProxyView(ProxyView):
             upstream = 'http://www.example.com'


### PR DESCRIPTION
Example from documentation
```python
from revproxy.views import ProxyView

urlpatterns = [
    url(r'^(?P<path>.*)$', ProxyView.as_view(upstream='http://example.com/')),
]
```
produces this error:
```
...
Django Version: 1.8.4
Python Version: 2.7.10
...
Traceback:
File "/home/vdemin/dev/django-1.8/venv/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.    response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/vdemin/dev/django-1.8/venv/lib/python2.7/site-packages/django/views/generic/base.py" in view
  65.    self = cls(**initkwargs)
File "/home/vdemin/dev/django-1.8/venv/lib/python2.7/site-packages/revproxy/views.py" in __init__
  50.    super(ProxyView, self).__init__(*args, **kwargs)
File "/home/vdemin/dev/django-1.8/venv/lib/python2.7/site-packages/django/views/generic/base.py" in __init__
  47.    setattr(self, key, value)

Exception Type: AttributeError at /
Exception Value: can't set attribute
```
Quick (and I hope correct) solution is a partial revert of commit https://github.com/TracyWebTech/django-revproxy/commit/a5c21a68e1d38bc3faf0b59ff451bb6a3319917e.