### PR TITLE
Fail to set upstream and diazo_rules when using as_view method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,10 @@
 
+0.9.7 (unreleased)
+==================
+
+* Bug fixed: property preventing to set upstream and diazo_rules (#53, #54) [@vdemin]
+
+
 0.9.6 (2015-09-09)
 ==================
 

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -40,6 +40,7 @@ class ProxyView(View):
     their responses.
 
     """
+    _upstream = None
 
     add_remote_user = False
     default_content_type = 'application/octet-stream'
@@ -60,7 +61,13 @@ class ProxyView(View):
 
     @property
     def upstream(self):
-        raise NotImplementedError('Upstream server must be set')
+        if not self._upstream:
+            raise NotImplementedError('Upstream server must be set')
+        return self._upstream
+
+    @upstream.setter
+    def upstream(self, value):
+        self._upstream = value
 
     def get_upstream(self, path):
         upstream = self.upstream
@@ -194,18 +201,24 @@ class ProxyView(View):
 
 
 class DiazoProxyView(ProxyView, ContextMixin):
-
+    _diazo_rules = None
     diazo_theme_template = 'diazo.html'
     html5 = False
 
     @property
     def diazo_rules(self):
-        child_class_file = sys.modules[self.__module__].__file__
-        app_path = os.path.abspath(os.path.dirname(child_class_file))
-        diazo_path = os.path.join(app_path, 'diazo.xml')
+        if not self._diazo_rules:
+            child_class_file = sys.modules[self.__module__].__file__
+            app_path = os.path.abspath(os.path.dirname(child_class_file))
+            diazo_path = os.path.join(app_path, 'diazo.xml')
 
-        self.log.debug("diazo_rules: %s", diazo_path)
-        return diazo_path
+            self.log.debug("diazo_rules: %s", diazo_path)
+            self._diazo_rules = diazo_path
+        return self._diazo_rules
+
+    @diazo_rules.setter
+    def diazo_rules(self, value):
+        self._diazo_rules = value
 
     def dispatch(self, request, path):
         response = super(DiazoProxyView, self).dispatch(request, path)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -26,6 +26,22 @@ class ViewTest(TestCase):
         view2 = ProxyView()
         self.assertIs(view1.http, view2.http)
 
+    def test_set_upstream_as_argument(self):
+        url = 'http://example.com/'
+        view = ProxyView.as_view(upstream=url)
+
+        request = self.factory.get('/')
+        response = view(request, '/')
+
+        headers = {u'Cookie': u''}
+        self.urlopen.assert_called_with('GET', url,
+                                        body=b'',
+                                        redirect=False,
+                                        retries=None,
+                                        preload_content=False,
+                                        decode_content=False,
+                                        headers=headers)
+
     def test_upstream_not_implemented(self):
         proxy_view = ProxyView()
         with self.assertRaises(NotImplementedError):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -26,6 +26,21 @@ class ViewTest(TestCase):
         view2 = ProxyView()
         self.assertIs(view1.http, view2.http)
 
+    @patch('revproxy.transformer.DiazoTransformer.transform')
+    def test_set_diazo_as_argument(self, transform):
+        url = 'http://example.com/'
+        rules = '/tmp/diazo.xml'
+        path = '/'
+
+        class CustomProxyView(DiazoProxyView):
+            upstream = url
+
+        view = CustomProxyView.as_view(diazo_rules='/tmp/diazo.xml')
+        request = self.factory.get(path)
+        view(request, path)
+
+        self.assertEqual(transform.call_args[0][0], rules)
+
     def test_set_upstream_as_argument(self):
         url = 'http://example.com/'
         view = ProxyView.as_view(upstream=url)


### PR DESCRIPTION
This error was reported in #53.

Closes #53.