### PR TITLE
Fixed a bug where the response headers would be a dic` instead of urllib3.HttpHeaderDict

### DIFF
--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -50,7 +50,7 @@ def get_django_response(proxy_response):
 
     logger.debug('Response headers: %s', getattr(response, '_headers'))
 
-    cookies = HTTPHeaderDict(headers).getlist('set-cookie')
+    cookies = HTTPHeaderDict(proxy_response.headers).getlist('set-cookie')
     logger.info('Checking for invalid cookies')
     for cookie_string in cookies:
         cookie_dict = cookie_from_string(cookie_string)

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -1,7 +1,7 @@
 import logging
 
-from requests.packages.urllib3._collections import HTTPHeaderDict
 
+from requests.packages.urllib3._collections import HTTPHeaderDict
 from .utils import cookie_from_string, should_stream, set_response_headers
 
 from django.http import HttpResponse, StreamingHttpResponse
@@ -10,6 +10,8 @@ from django.http import HttpResponse, StreamingHttpResponse
 DEFAULT_AMT = 2 ** 16
 
 logger = logging.getLogger('revproxy.response')
+
+
 
 
 def get_django_response(proxy_response):
@@ -26,7 +28,6 @@ def get_django_response(proxy_response):
     """
     status = proxy_response.status
     headers = proxy_response.headers
-    headers = HTTPHeaderDict(headers)
 
     logger.debug('Proxy response headers: %s', headers)
 
@@ -49,7 +50,7 @@ def get_django_response(proxy_response):
 
     logger.debug('Response headers: %s', getattr(response, '_headers'))
 
-    cookies = headers.getlist('set-cookie')
+    cookies = HTTPHeaderDict(headers).getlist('set-cookie')
     logger.info('Checking for invalid cookies')
     for cookie_string in cookies:
         cookie_dict = cookie_from_string(cookie_string)

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -1,5 +1,7 @@
 import logging
 
+from requests.packages.urllib3._collections import HTTPHeaderDict
+
 from .utils import cookie_from_string, should_stream, set_response_headers
 
 from django.http import HttpResponse, StreamingHttpResponse
@@ -24,6 +26,10 @@ def get_django_response(proxy_response):
     """
     status = proxy_response.status
     headers = proxy_response.headers
+    if isinstance(headers, HTTPHeaderDict):
+        headers = headers
+    else:
+        headers = HTTPHeaderDict(headers)
 
     logger.debug('Proxy response headers: %s', headers)
 
@@ -46,7 +52,7 @@ def get_django_response(proxy_response):
 
     logger.debug('Response headers: %s', getattr(response, '_headers'))
 
-    cookies = proxy_response.headers.getlist('set-cookie')
+    cookies = headers.getlist('set-cookie')
     logger.info('Checking for invalid cookies')
     for cookie_string in cookies:
         cookie_dict = cookie_from_string(cookie_string)

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -26,10 +26,7 @@ def get_django_response(proxy_response):
     """
     status = proxy_response.status
     headers = proxy_response.headers
-    if isinstance(headers, HTTPHeaderDict):
-        headers = headers
-    else:
-        headers = HTTPHeaderDict(headers)
+    headers = HTTPHeaderDict(headers)
 
     logger.debug('Proxy response headers: %s', headers)
 


### PR DESCRIPTION

I would like to use your project djago-revproxy in my project [backendfail](https://github.com/arpheno/backendfail/)

When I try to use the master version I get a `dict object has no attribute called getlist` error on python 2.7.10 ubuntu.

The fix response.py fixes this problem for me, please  consider merging it upstream, because I'd like to pull from pypi instead of keeping your trunk in my repo.