### PR TITLE
fix python 3 compatibility.

### DIFF
--- a/revproxy/connection.py
+++ b/revproxy/connection.py
@@ -6,7 +6,7 @@ from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 def _output(self, s):
     """Host header should always be first"""
 
-    if s.lower().startswith('host: '):
+    if s.lower().startswith(b'host: '):
         self._buffer.insert(1, s)
     else:
         self._buffer.append(s)


### PR DESCRIPTION
When using the newest code I get an exception in python 3.3. This was introduced in commit 2fd9a10e.

The bottom of the stack trace is as follows:

File "/usr/local/lib/python3.3/http/client.py", line 957, in putrequest
     self._output(request.encode('ascii'))
   File "/usr/local/lib/python3.3/site-packages/revproxy/connection.py", line 9, in _output
     if s.lower().startswith('host: '):

My change should work with python 3 and python 2.7

Regards,
Stefan