### PR TITLE
Fix connections in Python 3

### DIFF
--- a/revproxy/connection.py
+++ b/revproxy/connection.py
@@ -6,7 +6,7 @@ from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 def _output(self, s):
     """Host header should always be first"""
 
-    if s.lower().startswith('host: '):
+    if s.lower().startswith(b'host: '):
         self._buffer.insert(1, s)
     else:
         self._buffer.append(s)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from revproxy import connection
+
+
+class TestOutput(TestCase):
+
+    def setUp(self):
+        self.connection = connection.HTTPConnectionPool.ConnectionCls('example.com')
+
+    def test_byte_url(self):
+        """Output strings are always byte strings, even using Python 3"""
+        mock_output = b'mock output'
+        connection._output(self.connection, mock_output)
+        self.assertEqual(self.connection._buffer, [mock_output])
+
+    def test_host_is_first(self):
+        """Make sure the host line is second in the request"""
+        mock_host_output = b'host: example.com'
+        for output in [b'GET / HTTP/1.1', b'before', mock_host_output, b'after']:
+            connection._output(self.connection, output)
+        self.assertEqual(self.connection._buffer[1], mock_host_output)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,35 @@
+import mock
+
+from django.test import TestCase
+from urllib3.poolmanager import SSL_KEYWORDS
+
+from revproxy import connection, pool
+
+
+mock_http_pool = mock.Mock(wraps=connection.HTTPConnectionPool)
+
+
+class TestPoolManager(TestCase):
+
+    def test_new_pool(self):
+        new_pool = pool.PoolManager()._new_pool('https', 'example.com', '443')
+        self.assertIsInstance(new_pool, connection.HTTPSConnectionPool)
+
+    @mock.patch('revproxy.pool.pool_classes_by_scheme', {'http': mock_http_pool})
+    def test_new_http_pool(self):
+        example_ssl_key = SSL_KEYWORDS[0]
+        mock_non_ssl_key = 'mock_keyword'
+        mock_non_ssl_value = 'mock non-ssl value'
+        mock_host_and_port = ('example.com', '80')
+
+        pool_manager = pool.PoolManager()
+        pool_manager.connection_pool_kw.update({
+            example_ssl_key: 'mock ssl value',
+            mock_non_ssl_key: mock_non_ssl_value,
+        })
+        new_pool = pool_manager._new_pool('http', *mock_host_and_port)
+
+        mock_http_pool.assert_called_once_with(
+            *mock_host_and_port,
+            **{mock_non_ssl_key: mock_non_ssl_value}
+        )


### PR DESCRIPTION
I noticed a small bug in your latest release... It looks like output in urllib3 (as processed by the new `_output()` method) is always a byte string, even when using Python3.

I've attached a fix that should resolve it, as well as some basic tests for that code, since it isn't covered currently.