### PR TITLE
Fix transformation with wrong charset

### DIFF
--- a/revproxy/transformer.py
+++ b/revproxy/transformer.py
@@ -139,7 +139,16 @@ class DiazoTransformer(object):
         self.log.debug("Transform: %s", transform)
 
         charset = get_charset(self.response.get('Content-Type'))
-        content_doc = etree.fromstring(self.response.content.decode(charset),
+
+        try:
+            decoded_response = self.response.content.decode(charset)
+        except UnicodeDecodeError:
+            decoded_response = self.response.content.decode(charset, 'ignore')
+            self.log.warning("Charset is {} and type of encode used in file is\
+                              different. Some unknown characteres might be\
+                              ignored.".format(charset))
+
+        content_doc = etree.fromstring(decoded_response,
                                        parser=etree.HTMLParser())
 
         self.response.content = transform(content_doc)

--- a/tests/custom_diazo.xml
+++ b/tests/custom_diazo.xml
@@ -1,0 +1,8 @@
+<rules
+     xmlns="http://namespaces.plone.org/diazo"
+     xmlns:css="http://namespaces.plone.org/diazo/css"
+     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+     <before theme-children="/html" content-children="/html" />
+
+</rules>

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -278,7 +278,7 @@ class TransformerTest(TestCase):
             response = view(request, '/')
 
         self.assertIn(b'test', response.content)
-        self.assertNotIn(b'á', response.content)
+        self.assertNotIn(b'\xc3\xa1', response.content)
 
     def test_asbool(self):
         test_true = ['true', 'yes', 'on', 'y', 't', '1']

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -267,6 +267,19 @@ class TransformerTest(TestCase):
 
         self.assertIn(b'random data', response.content)
 
+    def test_transform_with_wrong_charset(self):
+        request = self.factory.get('/')
+        content = u'<html><body>átest</body><html>'.encode('utf-8')
+        headers = {'Content-Type': 'text/html; charset=ascii'}
+
+        urlopen_mock = get_urlopen_mock(content, headers)
+        with patch(URLOPEN, urlopen_mock):
+            view = CustomProxyView.as_view(diazo_rules='tests/custom_diazo.xml')
+            response = view(request, '/')
+
+        self.assertIn(b'test', response.content)
+        self.assertNotIn(b'á', response.content)
+
     def test_asbool(self):
         test_true = ['true', 'yes', 'on', 'y', 't', '1']
         for element in test_true:


### PR DESCRIPTION
When charset in Content-type HTTP header and the file encoding are different,
the unknown characters are ignored.