### PR TITLE
User.get_username() rather than User.name to support custom User models

### DIFF
--- a/revproxy/connection.py
+++ b/revproxy/connection.py
@@ -11,6 +11,7 @@ def _output(self, s):
     else:
         self._buffer.append(s)
 
+
 HTTPConnectionPool.ConnectionCls = type(
     'RevProxyHTTPConnection',
     (HTTPConnection,),

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -126,7 +126,7 @@ class ProxyView(View):
         request_headers = self.get_proxy_request_headers(self.request)
 
         if self.add_remote_user and self.request.user.is_active:
-            request_headers['REMOTE_USER'] = self.request.user.username
+            request_headers['REMOTE_USER'] = self.request.user.get_username()
             self.log.info("REMOTE_USER set")
 
         return request_headers


### PR DESCRIPTION
This adds support for custom `User` models which do not contain a `username` field: https://docs.djangoproject.com/en/1.10/ref/contrib/auth/#django.contrib.auth.models.User.get_username