### PR TITLE
Cookies with quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ env:
   - DJANGO_VERSION=1.10
 
 install:
-  - pip install coveralls flake8
+  # django-revproxy doesn't support versions of urllib3 past 1.17, so we need to
+  # ensure that we don't upgrade it when we install coveralls
+  - pip install coveralls flake8 "urllib3<1.17"
   - pip install django==${DJANGO_VERSION}
 
 script:

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -10,7 +10,7 @@ DEFAULT_AMT = 2 ** 16
 logger = logging.getLogger('revproxy.response')
 
 
-def get_django_response(proxy_response):
+def get_django_response(proxy_response, strict_cookies=False):
     """This method is used to create an appropriate response based on the
     Content-Length of the proxy_response. If the content is bigger than
     MIN_STREAMING_LENGTH, which is found on utils.py,
@@ -19,6 +19,7 @@ def get_django_response(proxy_response):
 
     :param proxy_response: An Instance of urllib3.response.HTTPResponse that
                            will create an appropriate response
+    :param strict_cookies: Whether to only accept RFC-compliant cookies
     :returns: Returns an appropriate response based on the proxy_response
               content-length
     """
@@ -49,7 +50,8 @@ def get_django_response(proxy_response):
     cookies = proxy_response.headers.getlist('set-cookie')
     logger.info('Checking for invalid cookies')
     for cookie_string in cookies:
-        cookie_dict = cookie_from_string(cookie_string)
+        cookie_dict = cookie_from_string(cookie_string,
+                                         strict_cookies=strict_cookies)
         # if cookie is invalid cookie_dict will be None
         if cookie_dict:
             response.set_cookie(**cookie_dict)

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -46,6 +46,7 @@ class ProxyView(View):
     default_content_type = 'application/octet-stream'
     retries = None
     rewrite = tuple()  # It will be overrided by a tuple inside tuple.
+    strict_cookies = False
 
     def __init__(self, *args, **kwargs):
         super(ProxyView, self).__init__(*args, **kwargs)
@@ -206,7 +207,8 @@ class ProxyView(View):
         self._replace_host_on_redirect_location(request, proxy_response)
         self._set_content_type(request, proxy_response)
 
-        response = get_django_response(proxy_response)
+        response = get_django_response(proxy_response,
+                                       strict_cookies=self.strict_cookies)
 
         self.log.debug("RESPONSE RETURNED: %s", response)
         return response

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,22 @@ class UtilsTest(TestCase):
         type(urlopen_mock).headers = PropertyMock(return_value=headers)
         self.assertEqual(True, utils.should_stream(urlopen_mock))
 
+    def test_strict_cookies(self):
+        valid_cookie = '_cookie_session="1234c12d4p=312341243";' \
+                       'expires=Thu, 29 Jan 2015 13:51:41 GMT; httponly;' \
+                       'secure;Path=/gitlab'
+        self.assertDictContainsSubset(
+            {
+                'expires': 'Thu, 29 Jan 2015 13:51:41 GMT',
+                'value': '1234c12d4p=312341243',
+            },
+            utils.cookie_from_string(valid_cookie, strict_cookies=True),
+        )
+
+        invalid_cookie = "_cookie_session:xyz"
+        self.assertIsNone(utils.cookie_from_string(invalid_cookie,
+                                                   strict_cookies=True))
+
     def test_get_dict_in_cookie_from_string(self):
         cookie = "_cookie_session = 1266bb13c139cfba3ed1c9c68110bae9;" \
                  "expires=Thu, 29 Jan 2015 13:51:41 -0000; httponly;" \

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,7 +30,8 @@ class ViewTest(TestCase):
         path = 'http://example.org'
         request = self.factory.get(path)
 
-        view = ProxyView.as_view(upstream='http://example.com/')
+        view = ProxyView.as_view(upstream='http://example.com/',
+                                 strict_cookies=True)
         view(request, path)
 
         headers = {u'Cookie': u''}


### PR DESCRIPTION
This change permits cookie values to be quoted and contain equal signs, e.g.:

`_cookie_session="hello=world"`