### PR TITLE
Add get_encoded_query_params() 

### DIFF
--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -136,6 +136,7 @@ class ProxyView(View):
         return quote_plus(path.encode('utf8'), QUOTE_SAFE)
    
     def get_encoded_query_params(self):
+        """Return encoded query params to be used in proxied request"""
         get_data = encode_items(request.GET.lists())
         return urlencode(get_data) 
 

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -134,6 +134,10 @@ class ProxyView(View):
     def get_quoted_path(self, path):
         """Return quoted path to be used in proxied request"""
         return quote_plus(path.encode('utf8'), QUOTE_SAFE)
+   
+    def get_encoded_query_params(self):
+        get_data = encode_items(request.GET.lists())
+        return urlencode(get_data) 
 
     def _created_proxy_response(self, request, path):
         request_payload = request.body
@@ -146,8 +150,7 @@ class ProxyView(View):
         self.log.debug("Request URL: %s", request_url)
 
         if request.GET:
-            get_data = encode_items(request.GET.lists())
-            request_url += '?' + urlencode(get_data)
+            request_url += '?' + self.get_encoded_query_params()
             self.log.debug("Request URL: %s", request_url)
 
         try:

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -137,7 +137,7 @@ class ProxyView(View):
    
     def get_encoded_query_params(self):
         """Return encoded query params to be used in proxied request"""
-        get_data = encode_items(request.GET.lists())
+        get_data = encode_items(self.request.GET.lists())
         return urlencode(get_data) 
 
     def _created_proxy_response(self, request, path):

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -134,11 +134,11 @@ class ProxyView(View):
     def get_quoted_path(self, path):
         """Return quoted path to be used in proxied request"""
         return quote_plus(path.encode('utf8'), QUOTE_SAFE)
-   
+
     def get_encoded_query_params(self):
         """Return encoded query params to be used in proxied request"""
         get_data = encode_items(self.request.GET.lists())
-        return urlencode(get_data) 
+        return urlencode(get_data)
 
     def _created_proxy_response(self, request, path):
         request_payload = request.body


### PR DESCRIPTION
This simply moves the *query parameter encoding* into it's own method so a sub-class can define how it should work.

For instance, the [OPeNDAP](https://www.opendap.org/) protocol supports queries like `http://example.com/file.nc?time[0:1:1]` but the current `urlencode` call encodes some characters that shouldn't be messed with.

A simple sub-class example:

```python
class ThreddsProxy(ProxyView):

    def get_encoded_query_params(self):
        # overridden to allow thredds query parameters like "?time[0:1:1]"
        get_data = encode_items(self.request.GET.lists())
        encoded_query = urlencode(get_data, safe='[]:')
        return encoded_query
```