### PR TITLE
 Handle quoted cookie values when `strict_cookies=False` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: xenial
+sudo: required
 
 sudo: false
 
@@ -10,11 +12,13 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 env:
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10
+  - DJANGO_VERSION=1.11
 
 install:
   - pip install coveralls flake8 urllib3

--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -128,7 +128,7 @@ def set_response_headers(response, response_headers):
 
 
 def normalize_request_headers(request):
-    """Function used to transform header, replacing 'HTTP\_' to ''
+    r"""Function used to transform header, replacing 'HTTP\_' to ''
     and replace '_' to '-'
 
     :param request:  A HttpRequest that will be transformed

--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -191,8 +191,8 @@ def cookie_from_string(cookie_string, strict_cookies=False):
 
         cookie_parts = cookie_string.split(';')
         try:
-            cookie_dict['key'], cookie_dict['value'] = \
-                cookie_parts[0].split('=', 1)
+            key, value = cookie_parts[0].split('=', 1)
+            cookie_dict['key'], cookie_dict['value'] = key, unquote(value)
         except ValueError:
             logger.warning('Invalid cookie: `%s`', cookie_string)
             return None
@@ -221,8 +221,21 @@ def cookie_from_string(cookie_string, strict_cookies=False):
                     # function docstring
                     continue
                 else:
-                    cookie_dict[attr] = value
+                    cookie_dict[attr] = unquote(value)
             else:
                 logger.warning('Unknown cookie attribute %s', attr)
 
         return cookie_dict
+
+
+def unquote(value):
+    """Remove wrapping quotes from a string.
+
+    :param value: A string that might be wrapped in double quotes, such
+                  as a HTTP cookie value.
+    :returns: Beginning and ending quotes removed and escaped quotes (``\"``)
+              unescaped
+    """
+    if len(value) > 1 and value[0] == '"' and value[-1] == '"':
+        value = value[1:-1].replace(r'\"', '"')
+    return value

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -23,7 +23,7 @@ from .utils import normalize_request_headers, encode_items
 # Chars that don't need to be quoted. We use same than nginx:
 #   https://github.com/nginx/nginx/blob/nginx-1.9/src/core/ngx_string.c
 #   (Lines 1433-1449)
-QUOTE_SAFE = '<.;>\(}*+|~=-$/_:^@)[{]&\'!,"`'
+QUOTE_SAFE = r'<.;>\(}*+|~=-$/_:^@)[{]&\'!,"`'
 
 
 ERRORS_MESSAGES = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,6 +88,19 @@ class UtilsTest(TestCase):
         self.assertIsNone(utils.cookie_from_string(invalid_cookie,
                                                    strict_cookies=True))
 
+    def test_quoted_value_cookies(self):
+        valid_cookie = '_cookie_session="1234c12d4p=312341243";' \
+                       'expires=Thu, 29 Jan 2015 13:51:41 GMT; httponly;' \
+                       'secure;Path="/gitlab"'
+        self.assertDictContainsSubset(
+            {
+                'expires': 'Thu, 29 Jan 2015 13:51:41 GMT',
+                'value': '1234c12d4p=312341243',
+                'path': '/gitlab',
+            },
+            utils.cookie_from_string(valid_cookie),
+        )
+
     def test_get_dict_in_cookie_from_string(self):
         cookie = "_cookie_session = 1266bb13c139cfba3ed1c9c68110bae9;" \
                  "expires=Thu, 29 Jan 2015 13:51:41 -0000; httponly;" \


### PR DESCRIPTION
Modifies `utils.cookie_from_string()` to handle cookie values wrapped in double quotes.

Also:
- Fix flake8 complaining about invalid escape sequences
- Add Python 3.7 and Django 1.11 to Travis tests