### PR TITLE
Import line was too long

### DIFF
--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -9,7 +9,8 @@ import logging
 import urllib3
 
 try:
-    from django.utils.six.moves.urllib.parse import urlparse, urlencode, quote_plus
+    from django.utils.six.moves.urllib.parse import (
+        urlparse, urlencode, quote_plus)
 except ImportError:
     # Django 3 has no six
     from urllib.parse import urlparse, urlencode, quote_plus


### PR DESCRIPTION
I'm terribly sorry @brianmay! :( This PR should fix the broken build: https://travis-ci.org/oktaal/django-revproxy. The import line became too long.